### PR TITLE
Replace Boost.Optional dependency with Boost.Variant2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ if(BOOST_ZLIB_IS_ROOT)
         config
         core
         optional
-        smart_ptr
         static_assert
         system
         throw_exception
@@ -104,7 +103,6 @@ target_link_libraries(boost_zlib
         Boost::config
         Boost::core
         Boost::optional
-        Boost::smart_ptr
         Boost::static_assert
         Boost::system
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,131 @@
+# Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
+# Copyright (c) 2021 Dmitry Arkhipov (grisumbras@gmail.com)
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Official repository: https://github.com/cppalliance/zlib
+#
+
+cmake_minimum_required(VERSION 3.8...3.16)
+
+if(BOOST_SUPERPROJECT_VERSION)
+    set(BOOST_ZLIB_VERSION VERSION ${BOOST_SUPERPROJECT_VERSION})
+endif()
+
+project(boost_zlib VERSION "${BOOST_ZLIB_VERSION}" LANGUAGES C CXX)
+
+
+set(BOOST_ZLIB_IS_ROOT OFF)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(BOOST_ZLIB_IS_ROOT ON)
+endif()
+
+if(BOOST_ZLIB_IS_ROOT)
+    include(CTest)
+endif()
+if(NOT BOOST_SUPERPROJECT_VERSION)
+    option(BOOST_ZLIB_INSTALL "Install boost::zlib files" ON)
+    option(BOOST_ZLIB_BUILD_TESTS "Build boost::zlib tests" ${BUILD_TESTING})
+else()
+    set(BOOST_ZLIB_BUILD_TESTS ${BUILD_TESTING})
+endif()
+
+
+include(GNUInstallDirs)
+if(BOOST_ZLIB_IS_ROOT)
+    # Building inside Boost tree, but as a separate project e.g. on Travis or
+    # other CI, or when producing Visual Studio Solution and Projects. This is
+    # when we have to add dependencies to the project manually.
+    foreach(lib
+        # direct dependencies
+        assert
+        config
+        core
+        optional
+        smart_ptr
+        static_assert
+        system
+        throw_exception
+        utility
+
+        # indirect dependencies
+        container_hash
+        detail
+        integer
+        io
+        move
+        predef
+        preprocessor
+        type_traits
+        winapi
+    )
+        add_subdirectory(../${lib} libs/${lib} EXCLUDE_FROM_ALL)
+        set(target boost_${lib})
+        if(TARGET ${target})
+          get_target_property(lib_type ${target} TYPE)
+          if(NOT ${lib_type} STREQUAL INTERFACE_LIBRARY)
+            set_property(TARGET ${target} PROPERTY FOLDER _deps/${lib})
+          endif()
+        endif()
+    endforeach()
+endif()
+
+
+file(GLOB_RECURSE BOOST_ZLIB_HEADERS CONFIGURE_DEPENDS
+    include/boost/*.hpp
+    include/boost/*.ipp
+)
+
+set(BOOST_ZLIB_SOURCES src/src.cpp)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/include/boost" PREFIX "" FILES ${BOOST_ZLIB_HEADERS})
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "" FILES ${BOOST_ZLIB_SOURCES})
+
+
+add_library(boost_zlib ${BOOST_ZLIB_HEADERS} ${BOOST_ZLIB_SOURCES})
+add_library(Boost::zlib ALIAS boost_zlib)
+target_compile_features(boost_zlib PUBLIC cxx_constexpr)
+target_compile_definitions(boost_zlib PUBLIC BOOST_ZLIB_NO_LIB=1)
+if(BOOST_SUPERPROJECT_VERSION)
+    target_include_directories(boost_zlib PUBLIC "${PROJECT_SOURCE_DIR}/include")
+else()
+    target_include_directories(boost_zlib
+        PUBLIC
+            "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    )
+endif()
+target_link_libraries(boost_zlib
+    PUBLIC
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::optional
+        Boost::smart_ptr
+        Boost::static_assert
+        Boost::system
+)
+
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(boost_zlib PUBLIC BOOST_ZLIB_DYN_LINK=1)
+else()
+    target_compile_definitions(boost_zlib PUBLIC BOOST_ZLIB_STATIC_LINK=1)
+endif()
+
+
+if(BOOST_ZLIB_INSTALL AND NOT BOOST_SUPERPROJECT_VERSION)
+    install(TARGETS boost_zlib
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    )
+endif()
+
+
+if(BOOST_ZLIB_BUILD_TESTS)
+    add_subdirectory(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,18 +42,18 @@ if(BOOST_ZLIB_IS_ROOT)
         assert
         config
         core
-        optional
         static_assert
         system
         throw_exception
         utility
+        variant2
 
         # indirect dependencies
         container_hash
         detail
         integer
         io
-        move
+        mp11
         predef
         preprocessor
         type_traits
@@ -102,9 +102,11 @@ target_link_libraries(boost_zlib
         Boost::assert
         Boost::config
         Boost::core
-        Boost::optional
         Boost::static_assert
         Boost::system
+        Boost::throw_exception
+        Boost::utility
+        Boost::variant2
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,18 +45,11 @@ if(BOOST_ZLIB_IS_ROOT)
         static_assert
         system
         throw_exception
-        utility
         variant2
 
         # indirect dependencies
-        container_hash
-        detail
-        integer
-        io
         mp11
         predef
-        preprocessor
-        type_traits
         winapi
     )
         add_subdirectory(../${lib} libs/${lib} EXCLUDE_FROM_ALL)
@@ -105,7 +98,6 @@ target_link_libraries(boost_zlib
         Boost::static_assert
         Boost::system
         Boost::throw_exception
-        Boost::utility
         Boost::variant2
 )
 

--- a/include/boost/zlib/detail/deflate_stream.hpp
+++ b/include/boost/zlib/detail/deflate_stream.hpp
@@ -42,7 +42,7 @@
 #include <boost/zlib/detail/ranges.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
-#include <boost/optional.hpp>
+#include <boost/variant2/variant.hpp>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
 #include <cstdlib>
@@ -258,7 +258,7 @@ protected:
         pending_buf_size_;          // size of pending_buf
     Byte* pending_out_;             // next pending byte to output to the stream
     uInt pending_;                  // nb of bytes in the pending buffer
-    boost::optional<Flush>
+    boost::variant2::variant<boost::variant2::monostate, Flush>
         last_flush_;                // value of flush param for previous deflate call
 
     uInt w_size_;                   // LZ77 window size (32K by default)
@@ -618,7 +618,7 @@ protected:
     std::size_t doUpperBound (std::size_t sourceLen) const;
     void doTune              (int good_length, int max_lazy, int nice_length, int max_chain);
     void doParams            (z_params& zs, int level, Strategy strategy, error_code& ec);
-    void doWrite             (z_params& zs, boost::optional<Flush> flush, error_code& ec);
+    void doWrite             (z_params& zs, boost::variant2::variant<boost::variant2::monostate, Flush> flush, error_code& ec);
     void doDictionary        (Byte const* dict, uInt dictLength, error_code& ec);
     void doPrime             (int bits, int value, error_code& ec);
     void doPending           (unsigned* value, int* bits);

--- a/include/boost/zlib/detail/impl/deflate_stream.ipp
+++ b/include/boost/zlib/detail/impl/deflate_stream.ipp
@@ -41,7 +41,6 @@
 #include <boost/zlib/detail/ranges.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
-#include <boost/make_unique.hpp>
 #include <boost/optional.hpp>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
@@ -617,8 +616,7 @@ init()
 
     if(! buf_ || buf_size_ != needed)
     {
-        buf_ = boost::make_unique_noinit<
-            std::uint8_t[]>(needed);
+        buf_.reset(new std::uint8_t[needed]);
         buf_size_ = needed;
     }
 

--- a/include/boost/zlib/detail/window.hpp
+++ b/include/boost/zlib/detail/window.hpp
@@ -38,7 +38,6 @@
 #define BOOST_ZLIB_DETAIL_WINDOW_HPP
 
 #include <boost/assert.hpp>
-#include <boost/make_unique.hpp>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -112,8 +111,7 @@ public:
     write(std::uint8_t const* in, std::size_t n)
     {
         if(! p_)
-            p_ = boost::make_unique<
-                std::uint8_t[]>(capacity_);
+            p_.reset(new std::uint8_t[capacity_]());
         if(n >= capacity_)
         {
             i_ = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
+# Copyright (c) 2021 Dmitry Arkhipov (grisumbras@gmail.com)
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Official repository: https://github.com/cppalliance/zlib
+#
+
+
+if(NOT TARGET tests)
+    add_custom_target(tests)
+    set_property(TARGET tests PROPERTY FOLDER _deps)
+endif()
+
+
+file(GLOB BOOST_ZLIB_TESTS_FILES CONFIGURE_DEPENDS Jamfile *.cpp *.hpp)
+list(APPEND BOOST_ZLIB_TESTS_FILES
+    extern/zlib-1.2.11/adler32.c
+    extern/zlib-1.2.11/compress.c
+    extern/zlib-1.2.11/crc32.c
+    extern/zlib-1.2.11/deflate.c
+    extern/zlib-1.2.11/infback.c
+    extern/zlib-1.2.11/inffast.c
+    extern/zlib-1.2.11/inflate.c
+    extern/zlib-1.2.11/inftrees.c
+    extern/zlib-1.2.11/trees.c
+    extern/zlib-1.2.11/uncompr.c
+    extern/zlib-1.2.11/zutil.c
+)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" PREFIX "" FILES ${BOOST_ZLIB_TESTS_FILES})
+add_executable(boost_zlib-tests ${BOOST_ZLIB_TESTS_FILES})
+target_include_directories(boost_zlib-tests PRIVATE .)
+target_link_libraries(boost_zlib-tests PRIVATE Boost::zlib)
+add_test(NAME boost_zlib-tests COMMAND boost_zlib-tests)
+add_dependencies(tests boost_zlib-tests)

--- a/test/deflate_stream.cpp
+++ b/test/deflate_stream.cpp
@@ -10,7 +10,6 @@
 // Test that header file is self-contained.
 #include <boost/zlib/deflate_stream.hpp>
 
-#include <boost/utility/string_view.hpp>
 #include "test_suite.hpp"
 #include <array>
 #include <cstdint>
@@ -154,7 +153,7 @@ public:
     static
     std::string
     compress(
-        string_view const& in,
+        std::string const& in,
         int level,                  // 0=none, 1..9, -1=default
         int windowBits,             // 9..15
         int memLevel)               // 1..9 (8=default)
@@ -191,7 +190,7 @@ public:
 
     static
     std::string
-    decompress(string_view const& in)
+    decompress(std::string const& in)
     {
         int result;
         std::string out;
@@ -444,9 +443,9 @@ public:
         c.init();
         std::string out;
         out.resize(1024);
-        string_view s = "Hello";
-        c.next_in(s.data());
-        c.avail_in(s.size());
+        auto& s = "Hello";
+        c.next_in(s);
+        c.avail_in(sizeof(s));
         c.next_out(&out.front());
         c.avail_out(out.size());
         error_code ec = c.write(Flush::sync);
@@ -455,8 +454,8 @@ public:
         c.avail_in(0);
         ec = c.write(Flush::finish);
         BOOST_TEST(ec == error::end_of_stream);
-        c.next_in(s.data());
-        c.avail_in(s.size());
+        c.next_in(s);
+        c.avail_in(sizeof(s));
         c.next_out(&out.front());
         c.avail_out(out.size());
         ec = c.write(Flush::sync);
@@ -471,9 +470,9 @@ public:
         c.init();
         std::string out;
         out.resize(1024);
-        string_view s = "Hello";
-        c.next_in(s.data());
-        c.avail_in(s.size());
+        auto& s = "Hello";
+        c.next_in(s);
+        c.avail_in(sizeof(s));
         c.next_out(&out.front());
         c.avail_out(out.size());
         error_code ec;

--- a/test/inflate_stream.cpp
+++ b/test/inflate_stream.cpp
@@ -10,7 +10,6 @@
 // Test that header file is self-contained.
 #include <boost/zlib/inflate_stream.hpp>
 
-#include <boost/utility/string_view.hpp>
 #include "test_suite.hpp"
 #include <chrono>
 #include <random>
@@ -152,7 +151,7 @@ public:
     static
     std::string
     compress(
-        string_view const& in,
+        std::string const& in,
         int level,                  // 0=none, 1..9, -1=default
         int windowBits,             // 9..15
         int memLevel,               // 1..9 (8=default)


### PR DESCRIPTION
In addition removes dependency on SmartPtr and Utility, and indirect dependencies: ContainerHash, Detail, Integer, Io, Preprocessor, and TypeTraits; but adds dependency on Mp11.